### PR TITLE
PCOsModel::Os and PCRandModel::operator()(value_t max)

### DIFF
--- a/wiselib.testing/external_interface/pc/pc_os_model.h
+++ b/wiselib.testing/external_interface/pc/pc_os_model.h
@@ -24,6 +24,7 @@ namespace wiselib {
 			const char** argv;
 
 			typedef PCOsModel AppMainParameter;
+			typedef PCOsModel Os;
 			
 			typedef uint32_t size_t;
 			typedef uint8_t block_data_t;

--- a/wiselib.testing/external_interface/pc/pc_rand.h
+++ b/wiselib.testing/external_interface/pc/pc_rand.h
@@ -30,6 +30,7 @@ namespace wiselib {
 			PCRandModel(value_t seed);
 			void srand(value_t seed);
 			value_t operator()();
+			value_t operator()(value_t max);
 			int state();
 			
 		private:
@@ -57,6 +58,12 @@ namespace wiselib {
 	operator()() {
 		return rand();
 	}
+
+	template<typename OsModel_P>
+	typename PCRandModel<OsModel_P>::value_t PCRandModel<OsModel_P>::
+	operator()( value_t max ) {
+	        return ( rand() % max );
+	}	
 	
 	template<typename OsModel_P>
 	int PCRandModel<OsModel_P>::


### PR DESCRIPTION
- commit d320056d3df8c22f8fb19884e15d71b2dc392b8b removed PCOsModel::Os, which ComISenseRadioModel is looking for
- added operator()(value_t max) to PCRandModel in order to be compatible to other rand models
