### PR TITLE
Shawn clock milliseconds

### DIFF
--- a/wiselib.testing/external_interface/shawn/shawn_clock.h
+++ b/wiselib.testing/external_interface/shawn/shawn_clock.h
@@ -73,7 +73,7 @@ namespace wiselib
       // --------------------------------------------------------------------
       uint16_t milliseconds( time_t time )
       {
-         return (uint16_t)(time - int(time)) * 1000;
+         return (uint16_t)((time - int(time)) * 1000);
       }
       // --------------------------------------------------------------------
       uint32_t seconds( time_t time )


### PR DESCRIPTION
The milliseconds( time_t time) function now returns the milliseconds. Before the update it returned the value 0 because the multiplication *1000 was done after the integer cast, causing the loss of the fractional part of the time (time_t is a double)
