### PR TITLE
Update wiselib.testing/util/pstl/static_string.h

### DIFF
--- a/wiselib.testing/util/pstl/static_string.h
+++ b/wiselib.testing/util/pstl/static_string.h
@@ -126,6 +126,10 @@ namespace wiselib {
         char* c_str() {
             return buffer_;
         }
+        
+        int size() const{
+            return length_;
+        }
 
         int length() const{
             return length_;


### PR DESCRIPTION
added a size function to remove ambiguity in static_string & string_dynamic.
